### PR TITLE
Add transparent background option to spritesheet and video previews

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -456,6 +456,13 @@ select.form-control {
     box-shadow: var(--shadow-md);
 }
 
+.video-container canvas {
+    max-width: 100%;
+    max-height: 400px;
+    border-radius: var(--radius-base);
+    box-shadow: var(--shadow-md);
+}
+
 .video-info {
     padding: var(--space-16);
     background: var(--color-bg-4);
@@ -934,4 +941,16 @@ input[type="file"] {
     width: 0 !important;
     height: 0 !important;
     opacity: 0 !important;
+}
+
+/* Transparent background toggle */
+.transparent-bg-control {
+    margin: var(--space-16) 0;
+}
+
+.transparent-bg-control label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-8);
+    font-size: var(--font-size-sm);
 }

--- a/html/preview.html
+++ b/html/preview.html
@@ -19,6 +19,12 @@
                             <canvas id="previewCanvas"></canvas>
                         </div>
                     </div>
+                    <div class="transparent-bg-control">
+                        <label>
+                            <input type="checkbox" id="transparentBgToggle">
+                            Replace black background with transparency
+                        </label>
+                    </div>
                     <div class="export-controls">
                         <button type="button" class="btn btn--primary btn--full-width" id="exportBtn">
                             Export PNG (Full Resolution)

--- a/html/video.html
+++ b/html/video.html
@@ -5,6 +5,13 @@
                         <video id="videoPlayer" controls>
                             Your browser does not support the video tag.
                         </video>
+                        <canvas id="videoCanvas" class="hidden"></canvas>
+                    </div>
+                    <div class="transparent-bg-control">
+                        <label>
+                            <input type="checkbox" id="videoTransparentBgToggle">
+                            Replace black background with transparency
+                        </label>
                     </div>
                     <div class="video-info" id="videoInfo">
                         <div class="video-metadata">

--- a/index.html
+++ b/index.html
@@ -50,6 +50,13 @@
                         <video id="videoPlayer" controls>
                             Your browser does not support the video tag.
                         </video>
+                        <canvas id="videoCanvas" class="hidden"></canvas>
+                    </div>
+                    <div class="transparent-bg-control">
+                        <label>
+                            <input type="checkbox" id="videoTransparentBgToggle">
+                            Replace black background with transparency
+                        </label>
                     </div>
                     <div class="video-info" id="videoInfo">
                         <div class="video-metadata">
@@ -207,6 +214,12 @@
                         <div class="canvas-wrapper" id="canvasWrapper">
                             <canvas id="previewCanvas"></canvas>
                         </div>
+                    </div>
+                    <div class="transparent-bg-control">
+                        <label>
+                            <input type="checkbox" id="transparentBgToggle">
+                            Replace black background with transparency
+                        </label>
                     </div>
                     <div class="export-controls">
                         <button type="button" class="btn btn--primary btn--full-width" id="exportBtn">


### PR DESCRIPTION
## Summary
- Add checkbox and canvas overlay to video preview for replacing black backgrounds with transparency
- Style video canvas and toggle to match existing layout
- Render video frames to canvas and reuse smooth black removal algorithm for clean transparent edges

## Testing
- `node --check js/SpritesheetGenerator.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897c754aab08320b29427c399f00428