### PR TITLE
Add spritesheet cropping feature

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -954,3 +954,26 @@ input[type="file"] {
     gap: var(--space-8);
     font-size: var(--font-size-sm);
 }
+
+/* Crop overlay */
+.crop-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.crop-modal canvas {
+    max-width: 90vw;
+    max-height: 80vh;
+}
+
+.crop-actions {
+    margin-top: var(--space-16);
+    display: flex;
+    gap: var(--space-8);
+    justify-content: center;
+}

--- a/index.html
+++ b/index.html
@@ -221,6 +221,11 @@
                             Replace black background with transparency
                         </label>
                     </div>
+                    <div class="crop-controls">
+                        <button type="button" class="btn btn--secondary btn--full-width" id="cropBtn" disabled>
+                            Crop Sprites
+                        </button>
+                    </div>
                     <div class="export-controls">
                         <button type="button" class="btn btn--primary btn--full-width" id="exportBtn">
                             Export PNG (Full Resolution)
@@ -232,6 +237,16 @@
                 </div>
             </section>
         </main>
+    </div>
+
+    <div id="cropOverlay" class="crop-overlay hidden">
+        <div class="crop-modal">
+            <canvas id="cropCanvas"></canvas>
+            <div class="crop-actions">
+                <button type="button" class="btn btn--primary" id="confirmCropBtn">Confirm Crop</button>
+                <button type="button" class="btn btn--secondary" id="cancelCropBtn">Cancel</button>
+            </div>
+        </div>
     </div>
 
     <script src="js/SpritesheetGenerator.js"></script>


### PR DESCRIPTION
## Summary
- add overlay to show first frame at full size for cropping
- confirm or cancel crop selection before regenerating spritesheet
- style full-screen crop overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689830465af48320b724091fe6473e58