### PR TITLE
Add animated GIF preview after spritesheet generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,8 @@ class SpritesheetGenerator {
         this.resetZoomBtn = document.getElementById('resetZoomBtn');
         this.exportBtn = document.getElementById('exportBtn');
         this.exportStatus = document.getElementById('exportStatus');
+        this.gifPreview = document.getElementById('gifPreview');
+        this.gifPreviewImg = document.getElementById('gifPreviewImg');
 
         // Time range elements
         this.startTime = document.getElementById('startTime');
@@ -506,6 +508,12 @@ class SpritesheetGenerator {
         this.isGenerating = true;
         this.cancelGeneration = false;
         this.extractedFrames = [];
+        if (this.gifPreview) {
+            this.gifPreview.classList.add('hidden');
+            if (this.gifPreviewImg) {
+                this.gifPreviewImg.src = '';
+            }
+        }
 
         try {
             this.showGenerationProgress();
@@ -530,6 +538,7 @@ class SpritesheetGenerator {
             this.displaySpritesheet(spritesheets, settings);
             this.hideGenerationProgress();
             this.showSuccess('Spritesheet generated successfully!');
+            this.generatePreviewGif(frames, settings);
 
         } catch (error) {
             console.error('Generation error:', error);
@@ -786,6 +795,34 @@ class SpritesheetGenerator {
         if (this.previewSection) {
             this.previewSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
+    }
+
+    async generatePreviewGif(frames, settings) {
+        if (!this.gifPreview || !this.gifPreviewImg || !frames.length) return;
+
+        const gif = new GIF({
+            workers: 2,
+            quality: 10,
+            workerScript: 'https://cdn.jsdelivr.net/npm/gif.js@0.2.0/dist/gif.worker.js'
+        });
+
+        for (const frame of frames) {
+            const img = new Image();
+            await new Promise((resolve, reject) => {
+                img.onload = resolve;
+                img.onerror = reject;
+                img.src = frame;
+            });
+            gif.addFrame(img, { delay: 1000 / (settings.fps || 30) });
+        }
+
+        gif.on('finished', (blob) => {
+            const url = URL.createObjectURL(blob);
+            this.gifPreviewImg.src = url;
+            this.gifPreview.classList.remove('hidden');
+        });
+
+        gif.render();
     }
 
     async seekToTime(video, time) {

--- a/index.html
+++ b/index.html
@@ -218,6 +218,10 @@
                             <canvas id="previewCanvas"></canvas>
                         </div>
                     </div>
+                    <div class="gif-preview hidden" id="gifPreview">
+                        <h3>Animation Preview</h3>
+                        <img id="gifPreviewImg" alt="Animation preview">
+                    </div>
                     <div class="export-controls">
                         <button type="button" class="btn btn--primary btn--full-width" id="exportBtn">
                             Export PNG (Full Resolution)
@@ -231,6 +235,7 @@
         </main>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/gif.js@0.2.0/dist/gif.js"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1266,6 +1266,18 @@ select.form-control {
     }
 }
 
+/* GIF preview */
+.gif-preview {
+    margin-top: var(--space-16);
+    text-align: center;
+}
+
+.gif-preview img {
+    max-width: 100%;
+    height: auto;
+    image-rendering: pixelated;
+}
+
 /* Hidden utility */
 .hidden {
     display: none !important;


### PR DESCRIPTION
## Summary
- integrate gif.js and add animation preview section
- generate GIF from extracted frames and display automatically
- style GIF preview and reset when regenerating

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68985a13c5988320b17c88413f25df07