### PR TITLE
Add automatic GIF preview after spritesheet generation

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -679,6 +679,21 @@ select.form-control {
     image-rendering: crisp-edges;
 }
 
+.gif-preview-container {
+    text-align: center;
+    margin-top: var(--space-16);
+}
+
+.gif-preview {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+    image-rendering: pixelated;
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+}
+
 /* Time Range Inputs */
 .time-range-inputs {
     display: grid;

--- a/index.html
+++ b/index.html
@@ -215,6 +215,10 @@
                             <canvas id="previewCanvas"></canvas>
                         </div>
                     </div>
+                    <div class="gif-preview-container">
+                        <h3>Animation Preview</h3>
+                        <img id="gifPreview" class="gif-preview hidden" alt="Animation preview">
+                    </div>
                     <div class="transparent-bg-control">
                         <label>
                             <input type="checkbox" id="transparentBgToggle">
@@ -312,6 +316,7 @@
         </div>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.js"></script>
     <script src="js/SpritesheetGenerator.js"></script>
     <script src="js/main.js"></script>
 </body>

--- a/js/SpritesheetGenerator.js
+++ b/js/SpritesheetGenerator.js
@@ -944,6 +944,35 @@ class SpritesheetGenerator {
         if (this.previewSection) {
             this.previewSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
+
+        this.createGifPreview(this.extractedFrames, settings.fps);
+    }
+
+    createGifPreview(frames, fps) {
+        const previewImg = document.getElementById('gifPreview');
+        if (!previewImg || !frames.length || typeof GIF === 'undefined') return;
+
+        previewImg.classList.add('hidden');
+
+        const gif = new GIF({
+            workers: 2,
+            quality: 10,
+            workerScript: 'https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.worker.js'
+        });
+
+        frames.forEach(frame => {
+            const img = document.createElement('img');
+            img.src = frame;
+            gif.addFrame(img, { delay: 1000 / fps });
+        });
+
+        gif.on('finished', blob => {
+            const url = URL.createObjectURL(blob);
+            previewImg.src = url;
+            previewImg.classList.remove('hidden');
+        });
+
+        gif.render();
     }
 
 


### PR DESCRIPTION
## Summary
- generate animated GIF preview using extracted frames
- show animation preview area and include gif.js dependency
- add styling for the GIF preview container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689872c48024832080427cc55424ec3f