### PR TITLE
Add smooth border to transparent sprites

### DIFF
--- a/js/SpritesheetGenerator.js
+++ b/js/SpritesheetGenerator.js
@@ -1512,6 +1512,22 @@ class SpritesheetGenerator {
             }
         }
         ctx.putImageData(imageData, 0, 0);
+        this.addSmoothBorder(ctx, width, height);
+    }
+
+    addSmoothBorder(ctx, width, height) {
+        const tempCanvas = document.createElement('canvas');
+        tempCanvas.width = width;
+        tempCanvas.height = height;
+        const tempCtx = tempCanvas.getContext('2d');
+        tempCtx.drawImage(ctx.canvas, 0, 0);
+
+        ctx.save();
+        ctx.globalCompositeOperation = 'destination-over';
+        ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+        ctx.shadowBlur = 2;
+        ctx.drawImage(tempCanvas, 0, 0);
+        ctx.restore();
     }
 
     async seekToTime(video, time) {


### PR DESCRIPTION
## Summary
- After making the spritesheet background transparent, apply a subtle black outline around elements for smoother edges.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689883c092f08320959895a2619cd25c