### PR TITLE
Fix large-screen responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
     <main class="container my-5">
         <div class="row g-4">
-            <div class="col-lg-6">
+            <div id="mainColumn" class="col-12">
                 <!-- Upload Section -->
                 <section class="card mb-4">
                     <div class="card-body">
@@ -182,9 +182,9 @@
                     </div>
                 </section>
             </div>
-            <div class="col-lg-6">
+            <div id="previewColumn" class="col-12 col-lg-6 hidden">
                 <!-- Preview Section -->
-                <section class="card mb-4 hidden" id="previewSection">
+                <section class="card mb-4" id="previewSection">
                     <div class="card-body">
                         <h2 class="h4 mb-3">4. Spritesheet Preview</h2>
                         <div class="d-flex flex-wrap gap-3 mb-3">

--- a/js/SpritesheetGenerator.js
+++ b/js/SpritesheetGenerator.js
@@ -102,6 +102,10 @@ class SpritesheetGenerator {
         this.exportBtn = document.getElementById('exportBtn');
         this.exportStatus = document.getElementById('exportStatus');
 
+        // Layout columns
+        this.mainColumn = document.getElementById('mainColumn');
+        this.previewColumn = document.getElementById('previewColumn');
+
         // Crop overlay elements
         this.cropOverlay = document.getElementById('cropOverlay');
         this.cropCanvas = document.getElementById('cropCanvas');
@@ -552,6 +556,17 @@ class SpritesheetGenerator {
 
         console.log('Handling file:', file.name, file.type);
 
+        // Reset preview layout when selecting a new file
+        if (this.previewColumn) {
+            this.previewColumn.classList.add('hidden');
+        }
+        if (this.mainColumn) {
+            this.mainColumn.classList.remove('col-lg-6');
+        }
+        if (this.previewSection) {
+            this.previewSection.classList.add('hidden');
+        }
+
         if (!file.type.startsWith('video/')) {
             this.showError('Please select a valid video file');
             return;
@@ -954,9 +969,15 @@ class SpritesheetGenerator {
             ctx.drawImage(spritesheets.previewCanvas, 0, 0);
         }
 
-        // Show preview section
+        // Show preview section and layout
         if (this.previewSection) {
             this.previewSection.classList.remove('hidden');
+        }
+        if (this.previewColumn) {
+            this.previewColumn.classList.remove('hidden');
+        }
+        if (this.mainColumn) {
+            this.mainColumn.classList.add('col-lg-6');
         }
 
         if (this.cropBtn) {


### PR DESCRIPTION
## Summary
- ensure main content fills width until preview is shown
- reveal preview column and resize layout when spritesheet preview is displayed
- reset layout when selecting a new video

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898fd73beb483209bea683935afa130