### PR TITLE
feat: add dark light theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Video to Spritesheet Generator</title>
+    <script>
+        const storedTheme = localStorage.getItem('color-scheme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = storedTheme || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-color-scheme', theme);
+        document.documentElement.setAttribute('data-bs-theme', theme);
+    </script>
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/components.css">
 
@@ -15,8 +22,9 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
 
-        <div class="container">
+        <div class="container d-flex justify-content-between align-items-center">
             <a class="navbar-brand" href="#">Spritesheet Maker</a>
+            <button id="themeToggle" class="btn btn-outline-light btn-sm" type="button">Dark Mode</button>
         </div>
     </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
     new SpritesheetGenerator();
+    initThemeToggle();
 });
+
+function initThemeToggle() {
+    const root = document.documentElement;
+    const toggle = document.getElementById('themeToggle');
+    if (!toggle) return;
+
+    const setTheme = (theme) => {
+        root.setAttribute('data-color-scheme', theme);
+        root.setAttribute('data-bs-theme', theme);
+        toggle.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+        localStorage.setItem('color-scheme', theme);
+    };
+
+    // Initialize button text based on current theme
+    setTheme(root.getAttribute('data-color-scheme') || 'light');
+
+    toggle.addEventListener('click', () => {
+        const current = root.getAttribute('data-color-scheme') === 'dark' ? 'light' : 'dark';
+        setTheme(current);
+    });
+}


### PR DESCRIPTION
## Summary
- add navbar toggle to switch between dark and light themes
- persist selected theme and sync with system preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0209782883208c93eded352b3dc9