### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -306,6 +306,8 @@ html {
   background-color: var(--color-background);
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
+  transition: background-color var(--duration-normal) var(--ease-standard),
+    color var(--duration-normal) var(--ease-standard);
 }
 
 body {

--- a/index.html
+++ b/index.html
@@ -24,7 +24,9 @@
 
         <div class="container d-flex justify-content-between align-items-center">
             <a class="navbar-brand" href="#">Spritesheet Maker</a>
-            <button id="themeToggle" class="btn btn-outline-light btn-sm" type="button">Dark Mode</button>
+            <button id="themeToggle" class="btn btn-outline-light btn-sm" type="button" aria-label="Toggle theme">
+                <span class="material-icons" id="themeIcon">dark_mode</span>
+            </button>
         </div>
     </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -6,20 +6,26 @@ document.addEventListener('DOMContentLoaded', () => {
 function initThemeToggle() {
     const root = document.documentElement;
     const toggle = document.getElementById('themeToggle');
-    if (!toggle) return;
+    const icon = document.getElementById('themeIcon');
+    if (!toggle || !icon) return;
 
     const setTheme = (theme) => {
         root.setAttribute('data-color-scheme', theme);
         root.setAttribute('data-bs-theme', theme);
-        toggle.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+        icon.textContent = theme === 'dark' ? 'light_mode' : 'dark_mode';
+        toggle.setAttribute(
+            'aria-label',
+            theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+        );
         localStorage.setItem('color-scheme', theme);
     };
 
-    // Initialize button text based on current theme
+    // Initialize button icon based on current theme
     setTheme(root.getAttribute('data-color-scheme') || 'light');
 
     toggle.addEventListener('click', () => {
-        const current = root.getAttribute('data-color-scheme') === 'dark' ? 'light' : 'dark';
+        const current =
+            root.getAttribute('data-color-scheme') === 'dark' ? 'light' : 'dark';
         setTheme(current);
     });
 }


### PR DESCRIPTION
## Summary
- Add nav bar button to switch between light and dark color schemes with a sun/moon icon
- Persist selected theme and update aria label for accessibility
- Animate background and text colors for smoother theme transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a021eea9483208de2bc07b3fadc24